### PR TITLE
jsonrpc is not a required response parameter

### DIFF
--- a/lib/Graze/Guzzle/JsonRpc/Message/Response.php
+++ b/lib/Graze/Guzzle/JsonRpc/Message/Response.php
@@ -32,7 +32,7 @@ class Response extends BaseResponse implements ResponseInterface
         parent::__construct($response->getStatusCode(), $response->getHeaders());
         $this->rpcFields = new Collection($data);
 
-        foreach (array('jsonrpc', 'id', 'result') as $key) {
+        foreach (array('id', 'result') as $key) {
             if (!$this->rpcFields->hasKey($key)) {
                 throw new OutOfRangeException('Parameter "' . $key . '" expected but not provided.');
             }

--- a/test/unit/lib/Graze/Guzzle/JsonRpc/Message/ResponseTest.php
+++ b/test/unit/lib/Graze/Guzzle/JsonRpc/Message/ResponseTest.php
@@ -80,23 +80,4 @@ class ResponseTest extends \Guzzle\Tests\GuzzleTestCase
             'id'      => 1
         ));
     }
-
-    public function testWithNoVersion()
-    {
-        $this->decorated->shouldReceive('getStatusCode')
-             ->once()
-             ->withNoArgs()
-             ->andReturn(200);
-        $this->decorated->shouldReceive('getHeaders')
-             ->once()
-             ->withNoArgs()
-             ->andReturn(array());
-
-        $this->setExpectedException('OutOfRangeException');
-
-        $response = new Response($this->decorated, $data = array(
-            'result'  => array('foo', 'bar'),
-            'id'      => 1
-        ));
-    }
 }


### PR DESCRIPTION
jsonrpc parameter is not deemed required by either the 1.0 or 2.0 [JSON-RPC Spec](http://www.jsonrpc.org/specification#response_object)

I removed the check in the response constructor and removed the test.
