### PR TITLE
Remove hhvm-nightly from the travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,11 @@ php:
   - 5.6
   - 7
   - hhvm
-  - hhvm-nightly
 
 matrix:
   allow_failures:
     - php: 7
     - php: hhvm
-    - php: hhvm-nightly
   fast_finish: true
 
 before_script:


### PR DESCRIPTION
The nightly build is no longer supported by the version of Ubuntu running on Travis CI.

See https://travis-ci.org/graze/guzzle-jsonrpc/jobs/80217510.