### PR TITLE
Add support for async requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,39 @@ $request->sendAll([
 ]);
 ```
 
+### Async requests
+Asynchronous requests are supported by making use of the
+[Guzzle Promises][guzzle-promise] library; an implementation of
+[Promises/A+][promise].
+```php
+<?php
+use Graze\GuzzleHttp\JsonRpc\Client;
+
+// Create the client
+$client = Client::factory('http://localhost:8000');
+
+// Send an async notification
+$promise = $client->sendAsync($client->notification('method', ['key'=>'value']));
+$promise->then(function () {
+    // Do something
+});
+
+// Send an async request that expects a response
+$promise = $client->sendAsync($client->request(123, 'method', ['key'=>'value']));
+$promise->then(function ($response) {
+    // Do something with the response
+});
+
+// Send a batch of requests
+$request->sendAllAsync([
+    $client->request(123, 'method', ['key'=>'value']),
+    $client->request(456, 'method', ['key'=>'value']),
+    $client->notification('method', ['key'=>'value'])
+])->then(function ($responses) {
+    // Do something with the list of responses
+});
+```
+
 ### Throw exception on RPC error
 You can throw an exception if you receive an RPC error response by adding the
 option `[rpc_error => true]` in the client constructor.
@@ -97,7 +130,9 @@ http://www.opensource.org/licenses/mit or in [`LICENSE`][license]
 [vagrant]: http://vagrantup.com
 [jsonrpc]: http://jsonrpc.org/specification
 [guzzle]: https://github.com/guzzle/guzzle
+[promise]: https://promisesaplus.com
 [guzzle-3]: https://github.com/guzzle/guzzle3
+[guzzle-promise]: https://github.com/guzzle/promises
 [branch-3]: https://github.com/graze/guzzle-jsonrpc/tree/guzzle-3
 [branch-4]: https://github.com/graze/guzzle-jsonrpc/tree/guzzle-4
 [branch-5]: https://github.com/graze/guzzle-jsonrpc/tree/guzzle-5

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require": {
         "php": ">=5.5",
         "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/promises": "^1.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -16,6 +16,7 @@ namespace Graze\GuzzleHttp\JsonRpc;
 
 use Graze\GuzzleHttp\JsonRpc\Message\RequestInterface;
 use Graze\GuzzleHttp\JsonRpc\Message\ResponseInterface;
+use GuzzleHttp\Promise\PromiseInterface;
 
 interface ClientInterface
 {
@@ -71,6 +72,18 @@ interface ClientInterface
     public function send(RequestInterface $request);
 
     /**
+     * Send a request asynchronously.
+     *
+     * This method sends a single request to the RPC server. The type of
+     * response is determined by the type of request.
+     *
+     * @param  RequestInterface       $request
+     *
+     * @return PromiseInterface
+     */
+    public function sendAsync(RequestInterface $request);
+
+    /**
      * Send a batch of requests.
      *
      * The intention of this method is to send the requests as a Batch Request
@@ -84,4 +97,19 @@ interface ClientInterface
      * @return ResponseInterface[]
      */
     public function sendAll(array $requests);
+
+    /**
+     * Send an asynchronous batch of requests.
+     *
+     * The intention of this method is to send the requests as a Batch Request
+     * where possible, and as separate requests where not possible. One reason
+     * a batch request isn't possible is where request URLs don't match.
+     *
+     * @link   http://www.jsonrpc.org/specification#batch
+     *
+     * @param  RequestInterface[]  $requests
+     *
+     * @return PromiseInterface
+     */
+    public function sendAllAsync(array $requests);
 }

--- a/test/functional/BatchFunctionalTest.php
+++ b/test/functional/BatchFunctionalTest.php
@@ -21,6 +21,14 @@ class BatchFunctionalTest extends FunctionalTestCase
         $this->client = $this->createClient();
     }
 
+    public function tearDown()
+    {
+        if (isset($this->promise)) {
+            $this->promise->wait(false); // Stop PHPUnit closing before async assertions
+            unset($this->promise);
+        }
+    }
+
     public function testBatchRequestWithOneChild()
     {
         $id = 'abc';
@@ -40,6 +48,29 @@ class BatchFunctionalTest extends FunctionalTestCase
         $this->assertEquals($id, $responses[0]->getRpcId());
         $this->assertEquals(null, $responses[0]->getRpcErrorCode());
         $this->assertEquals(null, $responses[0]->getRpcErrorMessage());
+    }
+
+    public function testAsyncBatchRequestWithOneChild()
+    {
+        $id = 'abc';
+        $method = 'sum';
+        $params = ['foo'=>123, 'bar'=>456];
+        $request = $this->client->request($id, $method, $params);
+        $this->promise = $this->client->sendAllAsync([$request]);
+
+        $this->promise->then(function ($response) use ($request, $id, $method, $params) {
+            $this->assertEquals(ClientInterface::SPEC, $request->getRpcVersion());
+            $this->assertEquals($id, $request->getRpcId());
+            $this->assertEquals($method, $request->getRpcMethod());
+            $this->assertEquals($params, $request->getRpcParams());
+
+            $this->assertTrue(is_array($responses));
+            $this->assertEquals(ClientInterface::SPEC, $responses[0]->getRpcVersion());
+            $this->assertEquals(array_sum($params), $responses[0]->getRpcResult());
+            $this->assertEquals($id, $responses[0]->getRpcId());
+            $this->assertEquals(null, $responses[0]->getRpcErrorCode());
+            $this->assertEquals(null, $responses[0]->getRpcErrorMessage());
+        });
     }
 
     public function testBatchRequestWithMultipleChildren()
@@ -109,5 +140,76 @@ class BatchFunctionalTest extends FunctionalTestCase
         $this->assertEquals($idD, $responseD->getRpcId());
         $this->assertTrue(is_int($responseD->getRpcErrorCode()));
         $this->assertTrue(is_string($responseD->getRpcErrorMessage()));
+    }
+
+    public function testAsyncBatchRequestWithMultipleChildren()
+    {
+        $idA = 123;
+        $idC = 'abc';
+        $idD = 'def';
+        $methodA = 'concat';
+        $methodB = 'nofify';
+        $methodC = 'sum';
+        $methodD = 'bar';
+        $paramsA = ['foo'=>'abc', 'bar'=>'def'];
+        $paramsB = ['foo'=>false];
+        $paramsC = ['foo'=>123, 'bar'=>456];
+        $paramsD = ['foo'=>123, 'bar'=>456];
+        $requestA = $this->client->request($idA, $methodA, $paramsA);
+        $requestB = $this->client->notification($methodB, $paramsB);
+        $requestC = $this->client->request($idC, $methodC, $paramsC);
+        $requestD = $this->client->request($idD, $methodD, $paramsD);
+        $this->promise = $this->client->sendAllAsync([$requestA, $requestB, $requestC, $requestD]);
+
+        $this->promise->then(function ($responses) use ($requestA, $requestB, $requestC, $requestD, $idA, $idC, $idD, $methodA, $methodB, $methodC, $methodD, $paramsA, $paramsB, $paramsC, $paramsD) {
+            $this->assertEquals(ClientInterface::SPEC, $requestA->getRpcVersion());
+            $this->assertEquals($idA, $requestA->getRpcId());
+            $this->assertEquals($methodA, $requestA->getRpcMethod());
+            $this->assertEquals($paramsA, $requestA->getRpcParams());
+            $this->assertEquals(ClientInterface::SPEC, $requestB->getRpcVersion());
+            $this->assertEquals(null, $requestB->getRpcId());
+            $this->assertEquals($methodB, $requestB->getRpcMethod());
+            $this->assertEquals($paramsB, $requestB->getRpcParams());
+            $this->assertEquals(ClientInterface::SPEC, $requestC->getRpcVersion());
+            $this->assertEquals($idC, $requestC->getRpcId());
+            $this->assertEquals($methodC, $requestC->getRpcMethod());
+            $this->assertEquals($paramsC, $requestC->getRpcParams());
+            $this->assertEquals(ClientInterface::SPEC, $requestD->getRpcVersion());
+            $this->assertEquals($idD, $requestD->getRpcId());
+            $this->assertEquals($methodD, $requestD->getRpcMethod());
+            $this->assertEquals($paramsD, $requestD->getRpcParams());
+
+            $this->assertTrue(is_array($responses));
+            $this->assertEquals(3, count($responses));
+
+            foreach ($responses as $response) {
+                if ($response->getRpcId() === $idA) {
+                    $responseA = $response;
+                } elseif ($response->getRpcId() === $idC) {
+                    $responseC = $response;
+                } elseif ($response->getRpcId() === $idD) {
+                    $responseD = $response;
+                }
+            }
+            if (!isset($responseA) || !isset($responseC) || !isset($responseD)) {
+                $this->fail('Invalid responses');
+            }
+
+            $this->assertEquals(ClientInterface::SPEC, $responseA->getRpcVersion());
+            $this->assertEquals(implode('', $paramsA), $responseA->getRpcResult());
+            $this->assertEquals($idA, $responseA->getRpcId());
+            $this->assertEquals(null, $responseA->getRpcErrorCode());
+            $this->assertEquals(null, $responseA->getRpcErrorMessage());
+            $this->assertEquals(ClientInterface::SPEC, $responseC->getRpcVersion());
+            $this->assertEquals(array_sum($paramsC), $responseC->getRpcResult());
+            $this->assertEquals($idC, $responseC->getRpcId());
+            $this->assertEquals(null, $responseC->getRpcErrorCode());
+            $this->assertEquals(null, $responseC->getRpcErrorMessage());
+            $this->assertEquals(ClientInterface::SPEC, $responseD->getRpcVersion());
+            $this->assertEquals(null, $responseD->getRpcResult());
+            $this->assertEquals($idD, $responseD->getRpcId());
+            $this->assertTrue(is_int($responseD->getRpcErrorCode()));
+            $this->assertTrue(is_string($responseD->getRpcErrorMessage()));
+        });
     }
 }

--- a/test/src/UnitTestCase.php
+++ b/test/src/UnitTestCase.php
@@ -49,6 +49,11 @@ class UnitTestCase extends TestCase
         return Mockery::mock('Graze\GuzzleHttp\JsonRpc\Message\MessageFactoryInterface');
     }
 
+    protected function mockPromise()
+    {
+        return Mockery::mock('GuzzleHttp\Promise\PromiseInterface');
+    }
+
     protected function mockRequest()
     {
         return Mockery::mock('Graze\GuzzleHttp\JsonRpc\Message\RequestInterface');


### PR DESCRIPTION
These changes allow the use of Guzzle 6's fairly nice promises abstraction.
The synchronous calls are still there but are now backed by awaiting promises.