### PR TITLE
Fix JSON parsing in PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7
     - php: hhvm
   fast_finish: true
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -43,8 +43,8 @@ function json_decode($json, $assoc = false, $depth = 512, $options = 0)
          JSON_ERROR_CTRL_CHAR => 'JSON_ERROR_CTRL_CHAR - Unexpected control character found',
          JSON_ERROR_SYNTAX => 'JSON_ERROR_SYNTAX - Syntax error, malformed JSON',
          JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded',
-     ];
-    $data = \json_decode($json, $assoc, $depth, $options);
+    ];
+    $data = \json_decode($json == "" ? "{}" : $json, $assoc, $depth, $options);
 
     if (JSON_ERROR_NONE !== json_last_error()) {
         $last = json_last_error();

--- a/src/functions.php
+++ b/src/functions.php
@@ -44,6 +44,8 @@ function json_decode($json, $assoc = false, $depth = 512, $options = 0)
          JSON_ERROR_SYNTAX => 'JSON_ERROR_SYNTAX - Syntax error, malformed JSON',
          JSON_ERROR_UTF8 => 'JSON_ERROR_UTF8 - Malformed UTF-8 characters, possibly incorrectly encoded',
     ];
+
+    // Patched support for decoding empty strings for PHP 7+
     $data = \json_decode($json == "" ? "{}" : $json, $assoc, $depth, $options);
 
     if (JSON_ERROR_NONE !== json_last_error()) {


### PR DESCRIPTION
It looks like json decoding an empty string doesn't work in PHP 7. Dunno why.
Tests pass in PHP 7 now.

![](https://media.giphy.com/media/PYEGoZXABBMuk/giphy.gif)
